### PR TITLE
Add rootly datasource alias and improve logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,6 @@ Once synced, search for Rootly data in Glean:
 
 ### Alerts & Monitoring
 - `Show latest alerts in Rootly`
+
+### All Rootly Documents
+- `app:rootly`: After connecting the new Rootly integration, please allow a few hours for Glean to fully index your Rootly documents.

--- a/app.py
+++ b/app.py
@@ -3,10 +3,11 @@
 One‑file Rootly → Glean sync with inline settings.
 """
 
-import coloredlogs
 import os
 import logging
 import time
+
+import coloredlogs
 
 # Import configuration management
 from config import get_config, config_manager
@@ -14,9 +15,10 @@ from config import get_config, config_manager
 # Load configuration
 config = get_config()
 coloredlogs.install(
-    level='INFO',
+    level=config.logging.level,
     fmt=config.logging.format,
 )
+logging.getLogger("httpx").setLevel(logging.INFO)
 
 logging.info("Configuration loaded successfully")
 logging.info(f"Using Glean datasource: {config.glean.datasource_name}")

--- a/app.py
+++ b/app.py
@@ -3,6 +3,7 @@
 One‑file Rootly → Glean sync with inline settings.
 """
 
+import coloredlogs
 import os
 import logging
 import time
@@ -12,13 +13,10 @@ from config import get_config, config_manager
 
 # Load configuration
 config = get_config()
-
-# Setup logging based on configuration
-logging.basicConfig(
-    level=getattr(logging, config.logging.level),
-    format=config.logging.format
+coloredlogs.install(
+    level='INFO',
+    fmt=config.logging.format,
 )
-logging.getLogger("httpx").setLevel(logging.INFO)
 
 logging.info("Configuration loaded successfully")
 logging.info(f"Using Glean datasource: {config.glean.datasource_name}")
@@ -80,7 +78,8 @@ def ensure_datasource(client: Glean) -> None:
         display_name=config.glean.display_name,
         datasource_category="TICKETS",
         url_regex="https://rootly.com/account/(incidents|alerts|schedules|escalation_policies)/.*",
-        object_definitions=get_object_definitions()
+        object_definitions=get_object_definitions(),
+        aliases=["rootly"],
     )
     
     try:

--- a/config.json
+++ b/config.json
@@ -44,6 +44,6 @@
   },
   "logging": {
     "level": "INFO",
-    "format": "%(asctime)s - %(levelname)s - %(message)s"
+    "format": "%(asctime)s,%(msecs)03d %(filename)s:%(lineno)d %(levelname)s %(message)s"
   }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+coloredlogs
 requests
 python-dateutil
 python-dotenv


### PR DESCRIPTION
* Add datasource alias as "rootly" so that Glean users can use "app:rootly" to search all rootly documents.
* Use coloredlogs to ensure logs are outputted to stdout/stderr properly and with more readable colors

<img width="990" height="222" alt="Screenshot 2025-10-23 at 2 32 53 PM" src="https://github.com/user-attachments/assets/ec80047a-538c-4d89-a7b5-c93a1d28a77b" />
