### PR TITLE
chore: add dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 3
     groups:
       minor-and-patch:
         update-types:
@@ -20,6 +22,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 3
     groups:
       minor-and-patch:
         update-types:


### PR DESCRIPTION
## Summary
- add a 3-day Dependabot cooldown to all configured ecosystems

## Testing
- not run (Dependabot config only)
