### PR TITLE
Use server_url from config instead of parsing instance name

### DIFF
--- a/app.py
+++ b/app.py
@@ -46,11 +46,10 @@ def glean_client() -> Glean:
     logging.info("Initializing Glean API client...")
 
     try:
-        instance_name = config_manager.get_instance_name()
-        logging.info(f"Using instance name: {instance_name}")
+        server_url = config_manager.get_server_url()
+        logging.info(f"Using server URL: {server_url}")
 
-        # Standard Glean client initialization
-        client = Glean(api_token=config.glean.api_token, instance=instance_name)
+        client = Glean(api_token=config.glean.api_token, server_url=server_url)
         logging.info("Glean API client initialized.")
         return client
 

--- a/config.py
+++ b/config.py
@@ -184,20 +184,10 @@ class ConfigManager:
         except json.JSONDecodeError as e:
             raise ValueError(f"Invalid JSON in configuration file: {e}") from e
 
-    def get_instance_name(self) -> str:
-        """Extract Glean instance name from API host"""
+    def get_server_url(self) -> str:
+        """Return the full backend server URL from the configured api_host."""
         config = self.load_config()
-        hostname = config.glean.api_host
-
-        # Extract instance name from hostname
-        instance_name = hostname.split(".")[0]
-        if "-be" in instance_name:
-            instance_name = instance_name.split("-be")[0]
-
-        if not instance_name:
-            raise ValueError(f"Could not derive instance name from host: {hostname}")
-
-        return instance_name
+        return f"https://{config.glean.api_host}"
 
 
 # Global configuration instance


### PR DESCRIPTION
## Summary
- Replace `get_instance_name()` (which parsed the hostname to extract an instance name) with `get_server_url()` that returns the full `https://{api_host}` URL
- Initialize the Glean client with `server_url=` instead of `instance=`
- Fixes initialization failures for obfuscated backend subdomains

Mirrors https://github.com/askscio/scio/pull/226891